### PR TITLE
Cache more

### DIFF
--- a/src/reedfrost/__init__.py
+++ b/src/reedfrost/__init__.py
@@ -8,6 +8,25 @@ from numpy.typing import NDArray
 
 
 @functools.cache
+def _rftp(i_next: int, s: int, i: int, p: float) -> float:
+    """Reed-Frost transition probability
+
+    Probability of there being i_next infections at the next step,
+    given there are currently s susceptibles, i infected, and the
+    infection probability is p.
+
+    Args:
+        i_next (int): next number of infected
+        s (int): current number of susceptibles
+        i (int): current number of infected
+        p (float): probability of infection
+
+    Returns:
+        float: probability mass
+    """
+    return _pmf_binom(k=i_next, n=s, p=1.0 - (1.0 - p) ** i)
+
+
 def _pmf_binom(k: int, n: int, p: float) -> float:
     """Binomial distribution pmf
 
@@ -46,8 +65,7 @@ def _pmf_s_inf(s_inf: int, s: int, i: int, p: float) -> float:
         return 0.0
     else:
         value = sum(
-            _pmf_binom(k=j, n=s, p=1.0 - (1.0 - p) ** i)
-            * _pmf_s_inf(s_inf=s_inf, s=s - j, i=j, p=p)
+            _rftp(i_next=j, s=s, i=i, p=p) * _pmf_s_inf(s_inf=s_inf, s=s - j, i=j, p=p)
             for j in range(s - s_inf + 1)
         )
 

--- a/src/reedfrost/__init__.py
+++ b/src/reedfrost/__init__.py
@@ -7,6 +7,7 @@ import scipy.stats
 from numpy.typing import NDArray
 
 
+@functools.cache
 def _pmf_binom(k: int, n: int, p: float) -> float:
     """Binomial distribution pmf
 


### PR DESCRIPTION
It struck me that we might be re-computing some of the transition probabilities $\text{Pr}(s\_{t + 1}, i\_{t + 1} \mid s\_t, i\_t, p)$.

I decided to test it empirically, and it looks like we are, because ~adding a `@functools.cache` decorator to `_pmf_binom`~ adding in an  `@functools.cache`-decorated intermediate Reed-Frost transition probability computation function speeds things up a bit.

```python
import numpy as np
import src.reedfrost as rf
import timeit

# No cache (main as of a322e46)
>>> timeit.timeit(lambda: rf.pmf(np.arange(25 + 1), 25, 1, 0.01), number=10000)
0.14906925899958878
>>> timeit.timeit(lambda: rf.pmf(np.arange(50 + 1), 50, 1, 0.01), number=10000)
0.6782971370012092
>>> timeit.timeit(lambda: rf.pmf(np.arange(100 + 1), 100, 1, 0.01), number=10000)
7.48441528299918

# Cache Binomial PMF (original version of this PR)
>>> timeit.timeit(lambda: rf.pmf(np.arange(25 + 1), 25, 1, 0.01), number=10000)
0.13539671299986367
>>> timeit.timeit(lambda: rf.pmf(np.arange(50 + 1), 50, 1, 0.01), number=10000)
0.4496703229997365
>>> timeit.timeit(lambda: rf.pmf(np.arange(100 + 1), 100, 1, 0.01), number=10000)
4.965679294999063

# Cache Reed-Frost PMF (this PR as of second commit)
>>> timeit.timeit(lambda: rf.pmf(np.arange(25 + 1), 25, 1, 0.01), number=10000)
0.13280062199999065
>>> timeit.timeit(lambda: rf.pmf(np.arange(50 + 1), 50, 1, 0.01), number=10000)
0.43253956500007007
>>> timeit.timeit(lambda: rf.pmf(np.arange(100 + 1), 100, 1, 0.01), number=10000)
4.382889264000028
```