### PR TITLE
Don't jitter origin

### DIFF
--- a/src/reedfrost/app.py
+++ b/src/reedfrost/app.py
@@ -77,7 +77,7 @@ def app():
                 min_value=5,
                 max_value=250,
                 step=1,
-                value=50,
+                value=100,
             )
 
             seed = st.number_input(


### PR DESCRIPTION
Don't jitter any of the points at t=0, so that all trajectories emerge from a single point.

This also means that the spacing between trajectories is mostly determined by the y=1 (e.g.) lines, rather than the origin

<img width="610" height="499" alt="image" src="https://github.com/user-attachments/assets/60b63e60-84b5-421b-b815-8e83d76c463e" />
