### PR TITLE
Separate input configuration from layout

### DIFF
--- a/src/reedfrost/app.py
+++ b/src/reedfrost/app.py
@@ -103,13 +103,8 @@ def get_params() -> dict:
             value=42,
         )
 
-    # derived parameters ------------------------------------------------------
-    n_susceptible = n - n_immune - n_infected
-    assert n_susceptible > 0
-
     return {
         "model": model,
-        "n_susceptible": n_susceptible,
         "n_infected": n_infected,
         "n_immune": n_immune,
         "brn": brn,
@@ -122,6 +117,11 @@ def get_params() -> dict:
 
 
 def get_results(params) -> dict:
+    # derive parameters
+    n_susceptible = params["n"] - params["n_immune"] - params["n_infected"]
+    assert n_susceptible > 0
+    params["n_susceptible"] = n_susceptible
+
     match (params["result_type"], params["metric"]):
         case ("Trajectories", _):
             return model_trajectories(params)


### PR DESCRIPTION
## Motivation

A typical streamlit pattern is `my_input_value = streamlit_component(arguments)`. In this pattern, the input value is put into the top-level namespace, the components must be placed in the code in the same order as they are to appear in the app, and all the arguments must appear in that same place.

This PR is an experiment designed to (1) encourage placement of input values into some object (e.g., a dictionary) rather than into the namespace and (2) decouple the "registration" and "placement" of components. These are new terms, so I'll explain.

## How to read this code

In the top-level `app()` function, we `register_inputs()`, creating an `Inputter`-class object. The `register_inputs()` function is repeated `inputter.register_component()` calls that say things like "there is a variable `"n"` which I want input via a slider that looks like so-and-so." (Sometimes the "so-and-so" is fixed, but other times it's a function of other inputs, so "so-and-so" is a "template" for the kwargs that the streamlit component will be called with. Put a pin in that.) These components are stored as `StreamlitComponent` objects inside the inputter.

Back in `app()`, we do the page layout, adding text, saying where the sidebar is, and indicating where components should be by calling `inputter.place_component("n")`. This `.place_component()` method in turn calls each `StreamlitComponent`'s `.__call__()` method. The `__call()__` hands the component the input values collected so far, allowing the UI for each component to depend on the values of the components placed before.

After the page layout is complete and the input values are collected, we extract the input values from the inputter, and run the simulations. Finally, we pass the input value and and the results to the `view()` function, which decides what plots to make and plots them.

## Pros

- Individual input values are not exposed in the `app()`-level namespace. Instead they are inside the inputter and are passed in one go to `get_results()`.
- Complete separation of individual component definition and styling from layout. The components can be registered in an order separate from placement. (There isn't complete independence: the DAG of component dependencies must match up with the order in which the components are placed, since streamlit runs top-to-bottom.)
- Related to the above: the `inputter.register_component()`s are pretty easy to read and make sense of for a layperson (until you get to a percent formatter like `lambda p: lambda x: f"{x / p['n']:.0%}"`, but that's not SME-reviewable text anyway).

## Cons

- Ideally, the component registration could just be a JSON or something, but I don't know how to square that with the fact that I want Python computations (e.g., one slider whose range depends on another). I could break `register_components()` out into a separate Python file. This challenge seems like one we will face in *any* language or framework.
- `Component` kludge. In one case, I need some branching logic that I couldn't hammer into the `StreamlitComponent` system. If the range of a slider would be minimum=maximum, then streamlit errors, whereas I just want a little piece of text that says "This value is ___". Presumably I could write a [custom component](https://docs.streamlit.io/develop/concepts/custom-components/create) to get around this.

## Open questions

- How does this idea of "registration" and "placement" map to JavaScript?