### PR TITLE
Use streamlit state

### DIFF
--- a/src/reedfrost/app/__init__.py
+++ b/src/reedfrost/app/__init__.py
@@ -1,11 +1,11 @@
 from reedfrost.app.controller import Controller
-from reedfrost.app.model import GETTERS, INITIAL_STATE
+from reedfrost.app.model import GETTERS, INITIAL_DATA
 from reedfrost.app.ui import COMPONENTS, app
 
 
 def main():
     Controller(
-        app=app, components=COMPONENTS, getters=GETTERS, initial_state=INITIAL_STATE
+        app=app, components=COMPONENTS, getters=GETTERS, initial_data=INITIAL_DATA
     ).run()
 
 

--- a/src/reedfrost/app/controller.py
+++ b/src/reedfrost/app/controller.py
@@ -1,5 +1,7 @@
 from typing import Callable
 
+import streamlit as st
+
 
 class Controller:
     def __init__(
@@ -7,12 +9,15 @@ class Controller:
         app: Callable,
         components: list[dict],
         getters: list[dict],
-        initial_state: dict | None = None,
+        initial_data: dict | None = None,
     ):
         self.app = app
         self.components = components
         self.getters = getters
-        self.state = initial_state or {}
+
+        if initial_data is not None:
+            for key, value in initial_data.items():
+                self.set(key, value, overwrite=False)
 
         # validate components
         for x in components:
@@ -34,31 +39,30 @@ class Controller:
             assert {"key", "getter"}.issubset(x.keys())
             assert callable(x["getter"])
 
-    def set(self, key: str, value) -> None:
-        self.state[key] = value
+    def set(self, key: str, value, overwrite: bool = True) -> None:
+        if overwrite or key not in st.session_state:
+            st.session_state[key] = value
 
     def get(self, key: str):
         # if there is a getter for this key, use it
         if getter := self._get_by_key(self.getters, key):
             return getter["getter"](self)
         else:
-            assert key in self.state or key == "results", f"Unknown key: {key}"
-            return self.state[key]
+            return st.session_state[key]
+
+    def ensure(self, key: str) -> None:
+        self.set(key, self.get(key))
 
     def place(self, key: str) -> None:
         # get the component with the given key
         item = self._get_by_key(self.components, key)
         assert item is not None
 
-        kwargs = {k: v for k, v in item.items() if k not in {"key", "type", "func"}}
+        kwargs = {k: v for k, v in item.items() if k not in {"type", "func"}}
 
         if item["type"] in {"input", "special_input"}:
             args = [self] if item["type"] == "special_input" else []
-            assert "value" not in kwargs
-            kwargs["value"] = self.get(key)
-
-            value = item["func"](*args, **kwargs)
-            self.set(key, value)
+            item["func"](*args, **kwargs)
         elif item["type"] == "output":
             item["func"](self)
         else:

--- a/src/reedfrost/app/model.py
+++ b/src/reedfrost/app/model.py
@@ -50,11 +50,11 @@ GETTERS = [
     {"key": "results", "getter": get_results},
 ]
 
-INITIAL_STATE = {
+INITIAL_DATA = {
     "n": 10,
     "n_immune": 0,
     "n_infected": 1,
-    "brn": 1.5,  # note this is clamped by n
+    "brn": 1.5,
     "model": "Reed-Frost",
     "result_type": "Trajectories",
     "metric": "Cumulative",

--- a/src/reedfrost/app/ui.py
+++ b/src/reedfrost/app/ui.py
@@ -6,6 +6,7 @@ from reedfrost.app.controller import Controller
 
 def app(c: Controller):
     """Run a streamlit app"""
+
     st.set_page_config(
         page_title="Chain binomial models", page_icon="🧮", layout="wide"
     )
@@ -37,11 +38,17 @@ def app(c: Controller):
 
 
 # Special purpose UI component functions -------------------------------------------------
-def n_immune(c: Controller, label: str, **kwargs) -> int:
+def n_immune(c: Controller, key: str, label: str, **kwargs):
+    # ensure that n_immune does not change when `options` changes
+    # see <https://docs.streamlit.io/develop/concepts/architecture/widget-behavior#retain-statefulness-when-changing-a-widgets-parameters>
+    c.ensure(key)
+
     n = c.get("n")
     assert isinstance(n, int) and n >= 1
-    return st.select_slider(
+
+    st.select_slider(
         label,
+        key=key,
         # values are from 0 to N-1, leaving space for at least 1 infected
         options=range(0, n),
         format_func=lambda x: f"{x / n:.0%}",
@@ -49,7 +56,7 @@ def n_immune(c: Controller, label: str, **kwargs) -> int:
     )
 
 
-def n_infected(c: Controller, label: str, **kwargs) -> int:
+def n_infected(c: Controller, key: str, label: str, **kwargs):
     # need special handling for the case where everyone is immune but 1,
     # because streamlit sliders must have a range
     n = c.get("n")
@@ -58,21 +65,22 @@ def n_infected(c: Controller, label: str, **kwargs) -> int:
     assert isinstance(n, int) and n >= 1
     assert isinstance(n_immune, int) and 0 <= n_immune < n
 
-    if n - n_immune == 1:
-        st.text(f"{label}: 1")
-        return 1
+    max_value = n - n_immune
+
+    help = f"No. infected is at most total no. ({n}) minus no. immune ({n_immune}) = {max_value}"
+
+    if max_value == 1:
+        st.text(f"{label}: 1", help=help)
+        c.set(key, 1)
     else:
-        return st.slider("No. initially infected", max_value=n - n_immune, **kwargs)
+        st.slider(label, key=key, max_value=max_value, help=help, **kwargs)
 
 
-def brn(c: Controller, label: str, max_value: float, value: float, **kwargs) -> float:
+def brn(c: Controller, key: str, label: str, max_value: float, **kwargs):
+    # ensure that R0 does not exceed N
     n = float(c.get("n"))
-    value = min(value, n)
-    return st.slider(label, max_value=min(max_value, n), value=value, **kwargs)
-
-
-def selectbox(label, options, value, **kwargs):
-    return st.selectbox(label, options=options, index=options.index(value), **kwargs)
+    c.set(key, min(c.get(key), n))
+    st.slider(label, key=key, max_value=min(max_value, n), **kwargs)
 
 
 # UI components ------------------------------------------------------------------------
@@ -83,7 +91,7 @@ COMPONENTS = [
         "type": "input",
         "func": st.slider,
         "label": "Population size",
-        "min_value": 1,
+        "min_value": 2,
         "max_value": 100,
         "step": 1,
     },
@@ -106,21 +114,21 @@ COMPONENTS = [
     {
         "key": "model",
         "type": "input",
-        "func": selectbox,
+        "func": st.selectbox,
         "label": "Model",
         "options": ["Reed-Frost", "Enko", "Greenwood"],
     },
     {
         "key": "result_type",
         "type": "input",
-        "func": selectbox,
+        "func": st.selectbox,
         "label": "Results type",
         "options": ["Trajectories", "Theoretical"],
     },
     {
         "key": "metric",
         "type": "input",
-        "func": selectbox,
+        "func": st.selectbox,
         "label": "Infections metric",
         "options": ["Cumulative", "Incident"],
     },


### PR DESCRIPTION
See e.g. https://docs.streamlit.io/develop/concepts/architecture/widget-behavior#retain-statefulness-when-changing-a-widgets-parameters for an explanation of why we need to use the streamlit widget calls to directly affect the session state.

Basically, if you ever change a widget's label, key, min/max/default value, etc., then streamlit considers it a new widget. (If it has the same key, it will put its data in the same place in the session state.) This creates a problem with default values. Here I take this approach:

1. When initializing the app, put the default values for the widgets into the session state.
2. Call the widget, being explicit about its key, so that streamlit knows to use the matching value from the session as the visible widget state (i.e., the default value) and also knows to put the resulting value into the session state with that key.

My previous approach was this:

1. When initializing the app, put the default values for the widgets into a state stored in the controller. (But also get the same problem, described below, if you put the data in the session state!)
2. Call with widget something like `my_state[key] = widget(value=my_state[key])`

The nice thing about this latter approach is that you can manage the app state separately from the streamlit session state. 

Unfortunately, you get some weird behavior where you can move a slider and streamlit will move it right back. I'm fairly certain this happens because, by changing `value=`, you are creating a new widget, and that somehow triggers a rerun.

So although it's kind of magical, I'm now saying "hey streamlit, make a widget with this key; you know to do with `st.session_state`" rather than what I would have *a priori* preferred, which is to say "hey streamlit, give me the new value from that widget, and then I'll put that into my state myself."